### PR TITLE
Improve performance of string matching and add Cache-variant FuzzySearchable protocol

### DIFF
--- a/Source/FuzzySearch.swift
+++ b/Source/FuzzySearch.swift
@@ -53,7 +53,7 @@ private extension String {
     // checking if string has prefix and returning prefix length on success
     func hasPrefix(_ prefix: CharOpts, atIndex index: Int) -> Int? {
         for pfx in [prefix.ch, prefix.normalized] {
-            if substring(from: characters.index(startIndex, offsetBy: index)).hasPrefix(pfx) {
+            if (self as NSString).substring(from: index).hasPrefix(pfx) {
                 return pfx.characters.count
             }
         }

--- a/Source/FuzzySearch.swift
+++ b/Source/FuzzySearch.swift
@@ -34,11 +34,6 @@ struct FuzzyTokens {
 }
 
 private extension String {
-    subscript(i: Int) -> Character? {
-        guard i >= 0 && i < characters.count else { return nil }
-        return self[characters.index(startIndex, offsetBy: i)]
-    }
-    
     func tokenize() -> [CharOpts] {
         return characters.map{
             let str = String($0).lowercased()

--- a/Source/FuzzySearch.swift
+++ b/Source/FuzzySearch.swift
@@ -8,9 +8,6 @@
 
 import Foundation
 
-/// For objc_setAssociatedObject
-private var _fuzzyCache: Int = 0
-
 struct CharOpts {
     let ch: String
     let normalized: String
@@ -18,14 +15,14 @@ struct CharOpts {
 
 /// A private cache containing pre-parsed metadata from a previous `.fuzzyMatch`
 /// call.
-class FuzzyCache {
+public class FuzzyCache {
     /// Hash of last fuzzed string
     internal var hash: Int?
     
     /// Array of last parsed fuzzy characters
     internal var lastTokenization: [CharOpts] = []
     
-    init() {
+    public init() {
         
     }
 }
@@ -73,38 +70,18 @@ public protocol FuzzySearchable {
     var fuzzyStringToMatch: String { get }
 }
 
-extension FuzzySearchable {
-    var fuzzyCache: FuzzyCache {
-        // Create cache, if not available yet
-        let cache: FuzzyCache
-        if let _cache = objc_getAssociatedObject(self, &_fuzzyCache) as? FuzzyCache {
-            cache = _cache
-        } else {
-            cache = FuzzyCache()
-            objc_setAssociatedObject(self, &_fuzzyCache, cache, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-        }
-        
-        return cache
-    }
-    
-    func fuzzyTokenized() -> FuzzyTokens {
-        let cache = fuzzyCache
-        
-        // Re-create fuzzy cache, if stale
-        if cache.hash == nil || cache.hash != fuzzyStringToMatch.hashValue {
-            let tokens = fuzzyStringToMatch.tokenize()
-            cache.hash = fuzzyStringToMatch.hashValue
-            cache.lastTokenization = tokens
-        }
-        
-        return FuzzyTokens(tokens: cache.lastTokenization)
-    }
+/// Variant of FuzzySearchable that allows for caching of the fuzzy strings
+public protocol CachedFuzzySearchable: FuzzySearchable {
+    var fuzzyCache: FuzzyCache { get }
 }
 
-public extension FuzzySearchable {
-    func fuzzyMatch(_ pattern: String) -> FuzzySearchResult {
-        let compareString = fuzzyTokenized().tokens
-        
+private extension FuzzySearchable {
+    func fuzzyTokenized() -> FuzzyTokens {
+        return FuzzyTokens(tokens: fuzzyStringToMatch.tokenize())
+    }
+    
+    /// Main fuzzy method - used by `fuzzyMatch` calls bellow along with `fuzzyTokenized`.
+    func fuzzyMatch(_ tokens: [CharOpts], _ pattern: String) -> FuzzySearchResult {
         let pattern = pattern.lowercased()
         
         var totalScore = 0
@@ -114,7 +91,7 @@ public extension FuzzySearchable {
         var currScore = 0
         var currPart = NSRange(location: 0, length: 0)
         
-        for (idx, strChar) in compareString.enumerated() {
+        for (idx, strChar) in tokens.enumerated() {
             if let prefixLength = pattern.hasPrefix(strChar, atIndex: patternIdx) {
                 patternIdx += prefixLength
                 currScore += 1 + currScore
@@ -138,6 +115,33 @@ public extension FuzzySearchable {
         } else {
             return FuzzySearchResult(weight: 0, parts: [])
         }
+    }
+}
+
+private extension CachedFuzzySearchable {
+    func fuzzyTokenized() -> FuzzyTokens {
+        // Re-create fuzzy cache, if stale
+        if fuzzyCache.hash == nil || fuzzyCache.hash != fuzzyStringToMatch.hashValue {
+            let tokens = fuzzyStringToMatch.tokenize()
+            fuzzyCache.hash = fuzzyStringToMatch.hashValue
+            fuzzyCache.lastTokenization = tokens
+        }
+        
+        return FuzzyTokens(tokens: fuzzyCache.lastTokenization)
+    }
+}
+
+public extension FuzzySearchable {
+    func fuzzyMatch(_ pattern: String) -> FuzzySearchResult {
+        let compareString = fuzzyTokenized().tokens
+        return fuzzyMatch(compareString, pattern)
+    }
+}
+
+public extension CachedFuzzySearchable {
+    func fuzzyMatch(_ pattern: String) -> FuzzySearchResult {
+        let compareString = fuzzyTokenized().tokens
+        return fuzzyMatch(compareString, pattern)
     }
 }
 

--- a/Tests/FuzzySearchTests.swift
+++ b/Tests/FuzzySearchTests.swift
@@ -15,8 +15,9 @@ extension String: FuzzySearchable {
     }
 }
 
-class CachedString: FuzzySearchable {
+struct CachedString: CachedFuzzySearchable {
     var fuzzyStringToMatch: String
+    var fuzzyCache: FuzzyCache = FuzzyCache()
     
     init(_ value: String) {
         self.fuzzyStringToMatch = value
@@ -50,7 +51,7 @@ class FuzzySearchTests: XCTestCase {
     }
     
     func testThatChangingFuzzyStringAffectsCache() {
-        let str = CachedString("Ladies Wash, Cut & Blow Dry")
+        var str = CachedString("Ladies Wash, Cut & Blow Dry")
         
         XCTAssertEqual(str.fuzzyMatch("l").weight, 1)
         XCTAssertEqual(str.fuzzyMatch("la").weight, 4)

--- a/Tests/FuzzySearchTests.swift
+++ b/Tests/FuzzySearchTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import FuzzySearch
+@testable import FuzzySearch
 
 extension String: FuzzySearchable {
     public var fuzzyStringToMatch: String {
@@ -65,6 +65,8 @@ class FuzzySearchTests: XCTestCase {
         XCTAssertEqual(str.fuzzyMatch("we").weight, 4)
         XCTAssertEqual(str.fuzzyMatch("wei").weight, 11)
         XCTAssertEqual(str.fuzzyMatch("weir").weight, 26)
+        
+        XCTAssertEqual(str.fuzzyCache.lastTokenization.count, str.fuzzyStringToMatch.characters.count)
     }
     
     func testThatCorrectMatchingPartsAreReturned() {

--- a/Tests/FuzzySearchTests.swift
+++ b/Tests/FuzzySearchTests.swift
@@ -15,9 +15,8 @@ extension String: FuzzySearchable {
     }
 }
 
-struct CachedString: CachedFuzzySearchable {
+class CachedString: FuzzySearchable {
     var fuzzyStringToMatch: String
-    var fuzzyCache: FuzzyCache = FuzzyCache()
     
     init(_ value: String) {
         self.fuzzyStringToMatch = value
@@ -51,7 +50,7 @@ class FuzzySearchTests: XCTestCase {
     }
     
     func testThatChangingFuzzyStringAffectsCache() {
-        var str = CachedString("Ladies Wash, Cut & Blow Dry")
+        let str = CachedString("Ladies Wash, Cut & Blow Dry")
         
         XCTAssertEqual(str.fuzzyMatch("l").weight, 1)
         XCTAssertEqual(str.fuzzyMatch("la").weight, 4)

--- a/Tests/FuzzySearchTests.swift
+++ b/Tests/FuzzySearchTests.swift
@@ -15,6 +15,15 @@ extension String: FuzzySearchable {
     }
 }
 
+struct CachedString: CachedFuzzySearchable {
+    var fuzzyStringToMatch: String
+    var fuzzyCache: FuzzyCache = FuzzyCache()
+    
+    init(_ value: String) {
+        self.fuzzyStringToMatch = value
+    }
+}
+
 extension NSRange: Equatable {}
 public func ==(lhs: NSRange, rhs: NSRange) -> Bool {
     return lhs.length == rhs.length && lhs.location == rhs.location
@@ -29,6 +38,33 @@ class FuzzySearchTests: XCTestCase {
         XCTAssertEqual(str.fuzzyMatch("lad").weight, 11)
         XCTAssertEqual(str.fuzzyMatch("ladi").weight, 26)
         XCTAssertEqual(str.fuzzyMatch("ladie").weight, 57)
+    }
+    
+    func testThatConsecutiveMatchingGives2xForEachChar_Cached() {
+        let str = CachedString("Ladies Wash, Cut & Blow Dry")
+        
+        XCTAssertEqual(str.fuzzyMatch("l").weight, 1)
+        XCTAssertEqual(str.fuzzyMatch("la").weight, 4)
+        XCTAssertEqual(str.fuzzyMatch("lad").weight, 11)
+        XCTAssertEqual(str.fuzzyMatch("ladi").weight, 26)
+        XCTAssertEqual(str.fuzzyMatch("ladie").weight, 57)
+    }
+    
+    func testThatChangingFuzzyStringAffectsCache() {
+        var str = CachedString("Ladies Wash, Cut & Blow Dry")
+        
+        XCTAssertEqual(str.fuzzyMatch("l").weight, 1)
+        XCTAssertEqual(str.fuzzyMatch("la").weight, 4)
+        XCTAssertEqual(str.fuzzyMatch("lad").weight, 11)
+        XCTAssertEqual(str.fuzzyMatch("ladi").weight, 26)
+        XCTAssertEqual(str.fuzzyMatch("ladie").weight, 57)
+        
+        str.fuzzyStringToMatch = "Weird Assassin"
+        
+        XCTAssertEqual(str.fuzzyMatch("w").weight, 1)
+        XCTAssertEqual(str.fuzzyMatch("we").weight, 4)
+        XCTAssertEqual(str.fuzzyMatch("wei").weight, 11)
+        XCTAssertEqual(str.fuzzyMatch("weir").weight, 26)
     }
     
     func testThatCorrectMatchingPartsAreReturned() {
@@ -86,6 +122,17 @@ class FuzzySearchTests: XCTestCase {
         let spanishWords: Array<String> = try! JSONSerialization.jsonObject(with: jsonData as Data, options: JSONSerialization.ReadingOptions.mutableContainers) as! Array<String>
         measure{
             _ = spanishWords.fuzzyMatch("la sart")
+        }
+    }
+    
+    func testSpeedOfFuzzySearchFor1000SpanishWords_cached() {
+        let path = Bundle(for: type(of: self)).path(forResource: "spanish-words", ofType: "json")!
+        let jsonData = try! Data(contentsOf: URL(fileURLWithPath: path), options: .mappedIfSafe)
+        let spanishWords: Array<String> = try! JSONSerialization.jsonObject(with: jsonData as Data, options: JSONSerialization.ReadingOptions.mutableContainers) as! Array<String>
+        let spanishWordsCached = spanishWords.map(CachedString.init)
+        
+        measure {
+            _ = spanishWordsCached.fuzzyMatch("la sart")
         }
     }
 }


### PR DESCRIPTION
These changes aim to improve speed of re-parsing the same string many times.
I bumped into this while adding fuzzy search for a combo box that had ~1000 values, and I noticed that the lib was splitting `fuzzyStringToMatch` over and over again even though it did not change for each combo box entry.

Aiming to solve this, I've added a CachedFuzzySearchable that adds an opaque cache of pre-tokenized strings to match against, and keeps track of changes by checking the string's hash match. Implementers simply have to add a caching field `var fuzzyCache: FuzzyCache = FuzzyCache()`, and the code handles `fuzzyStringToMatch` changes in the cache automatically, as well.

I've also changed a `String.substring` call to cast to NSString and use `NSString.substring(from:)`, seems like it's faster this way.

Great little library, by the way!

Cheers.