### PR TITLE
Explicit `CachedFuzzySearchable<T>` wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ players.fuzzyMatch("di")
 //]
 ```
 
-#### `CachedFuzzySearchable<T: FuzzySearchable>`
+### `CachedFuzzySearchable<T: FuzzySearchable>`
 
 Wraps over a `FuzzySearchable` instance, caching some underlying metadata generated while fuzzy-matching w/ `FuzzySearchable.fuzzyMatch`.
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ players.fuzzyMatch("di") // Will fuzzy-match against original, non-cached Player
 
 `CachedFuzzySearchable` has storage needs of a little over 2x that of the `fuzzyStringToSearch` property of the wrapped `FuzzySearchable` value. Discarding a `CachedFuzzySearchable` value also discards the extra memory that was allocated.
 
-Returning a different value from the wrapped `FuzzySearchable`'s `fuzzyStringToSearch` property resets the cache automatically during the next `fuzzyMatch` call and the overhead is reset to that of a fresh `CachedFuzzySearchable` instance, so implementers shouldn't worry .
+Returning a different value from the wrapped `FuzzySearchable`'s `fuzzyStringToSearch` property resets the cache automatically during the next `fuzzyMatch` call and the overhead is reset to that of a fresh `CachedFuzzySearchable` instance, so implementers shouldn't worry about mantaining a stable `fuzzyStringToSearch` result.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ players.fuzzyMatch("di") // Will fuzzy-match against original, non-cached Player
 
 `CachedFuzzySearchable` has storage needs of a little over 2x that of the `fuzzyStringToSearch` property of the wrapped `FuzzySearchable` value. Discarding a `CachedFuzzySearchable` value also discards the extra memory that was allocated.
 
-Returning a different value from the wrapped `FuzzySearchable`'s `fuzzyStringToSearch` property resets the cache automatically during the next `fuzzyMatch` call and the overhead is reset to that of a fresh `CachedFuzzySearchable` instance, so implementers shouldn't worry about mantaining a stable `fuzzyStringToSearch` result.
+Returning a different value from the wrapped `FuzzySearchable`'s `fuzzyStringToSearch` property resets the cache automatically during the next `fuzzyMatch` call and the overhead is reset to that of a fresh `CachedFuzzySearchable` instance, so implementers shouldn't worry about mantaining a stable `fuzzyStringToSearch` return.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,37 @@ players.fuzzyMatch("di")
 //]
 ```
 
+#### `CachedFuzzySearchable<T: FuzzySearchable>`
+
+Wraps over a `FuzzySearchable` instance, caching some underlying metadata generated while fuzzy-matching w/ `FuzzySearchable.fuzzyMatch`.
+
+Use this cached wrapper over `FuzzySearchable` instances that are expected to be fuzzy-matched multiple times without mutation to `fuzzyStringToMatch`:
+
+```swift
+let players = [
+  PlayerModel(name: "Diego Maradona", position: "CF", goals: 16),
+  PlayerModel(name: "David Beckham", position: "CAM", goals: 8),
+  PlayerModel(name: "Lionel Messi", position: "RW", goals: 15),
+  // Many more players ...
+]
+
+let fuzzyCachedPlayers =
+  players.map { player in 
+    CachedFuzzySearchable(wrapping: player) 
+  }
+
+fuzzyCachedPlayers.fuzzyMatch("di")
+
+// Subsequente calls to 'fuzzyMatch' over the array above cause less overhead when re-matching
+fuzzyCachedPlayers.fuzzyMatch("di") // Runs in about half time
+
+players.fuzzyMatch("di") // Will fuzzy-match against original, non-cached PlayerModel values.
+```
+
+`CachedFuzzySearchable` has storage needs of a little over 2x that of the `fuzzyStringToSearch` property of the wrapped `FuzzySearchable` value. Discarding a `CachedFuzzySearchable` value also discards the extra memory that was allocated.
+
+Returning a different value from the wrapped `FuzzySearchable`'s `fuzzyStringToSearch` property resets the cache automatically during the next `fuzzyMatch` call and the overhead is reset to that of a fresh `CachedFuzzySearchable` instance, so implementers shouldn't worry .
+
 ## License
 
 FuzzySearch is released under the [MIT](LICENSE) license.

--- a/Source/FuzzySearch.swift
+++ b/Source/FuzzySearch.swift
@@ -21,7 +21,7 @@ internal class FuzzyCache {
     internal var hash: Int?
     
     /// Array of last parsed fuzzy characters
-    internal var lastTokenization: [CharOpts] = []
+    internal var lastTokenization = FuzzyTokens(tokens: [])
     
     internal init() {
         
@@ -99,10 +99,10 @@ public struct CachedFuzzySearchable<T> : FuzzySearchable where T : FuzzySearchab
         if fuzzyCache.hash == nil || fuzzyCache.hash != fuzzyStringToMatch.hashValue {
             let tokens = fuzzyStringToMatch.tokenize()
             fuzzyCache.hash = fuzzyStringToMatch.hashValue
-            fuzzyCache.lastTokenization = tokens
+            fuzzyCache.lastTokenization = FuzzyTokens(tokens: tokens)
         }
         
-        return FuzzyTokens(tokens: fuzzyCache.lastTokenization)
+        return fuzzyCache.lastTokenization
     }
 }
 

--- a/Source/FuzzySearch.swift
+++ b/Source/FuzzySearch.swift
@@ -35,11 +35,6 @@ public struct FuzzyTokens {
 }
 
 private extension String {
-    subscript(i: Int) -> Character? {
-        guard i >= 0 && i < characters.count else { return nil }
-        return self[characters.index(startIndex, offsetBy: i)]
-    }
-    
     func tokenize() -> [CharOpts] {
         return characters.map{
             let str = String($0).lowercased()

--- a/Source/FuzzySearch.swift
+++ b/Source/FuzzySearch.swift
@@ -33,7 +33,7 @@ private extension String {
     // checking if string has prefix and returning prefix length on success
     func hasPrefix(_ prefix: CharOpts, atIndex index: Int) -> Int? {
         for pfx in [prefix.ch, prefix.normalized] {
-            if substring(from: characters.index(startIndex, offsetBy: index)).hasPrefix(pfx) {
+            if (self as NSString).substring(from: index).hasPrefix(pfx) {
                 return pfx.characters.count
             }
         }

--- a/Source/FuzzySearch.swift
+++ b/Source/FuzzySearch.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-private struct CharOpts {
+internal struct CharOpts {
     let ch: String
     let normalized: String
 }
@@ -16,14 +16,14 @@ private struct CharOpts {
 /// A private cache containing pre-parsed metadata from a previous `.fuzzyMatch`
 /// call.
 /// Used by CachedFuzzySearchable<T> bellow.
-public class FuzzyCache {
+internal class FuzzyCache {
     /// Hash of last fuzzed string
-    fileprivate var hash: Int?
+    internal var hash: Int?
     
     /// Array of last parsed fuzzy characters
-    fileprivate var lastTokenization: [CharOpts] = []
+    internal var lastTokenization: [CharOpts] = []
     
-    public init() {
+    internal init() {
         
     }
 }
@@ -34,7 +34,7 @@ public struct FuzzyTokens {
     fileprivate var tokens: [CharOpts]
 }
 
-private extension String {
+internal extension String {
     func tokenize() -> [CharOpts] {
         return characters.map{
             let str = String($0).lowercased()
@@ -76,8 +76,8 @@ public extension FuzzySearchable {
 
 /// Container over a FuzzySearchable that allows caching of the fuzzy contents.
 public struct CachedFuzzySearchable<T> : FuzzySearchable where T : FuzzySearchable {
-    fileprivate let searchable: T
-    fileprivate var fuzzyCache = FuzzyCache()
+    internal let searchable: T
+    internal let fuzzyCache = FuzzyCache()
     
     public init(searchable: T) {
         self.searchable = searchable

--- a/Source/FuzzySearch.swift
+++ b/Source/FuzzySearch.swift
@@ -62,6 +62,8 @@ public struct FuzzySearchResult {
     public let parts: [NSRange]
 }
 
+/// Specifies that a value exposes a string fit for fuzzy-matching against string
+/// patterns.
 public protocol FuzzySearchable {
     var fuzzyStringToMatch: String { get }
     
@@ -74,13 +76,18 @@ public extension FuzzySearchable {
     }
 }
 
-/// Container over a FuzzySearchable that allows caching of the fuzzy contents.
+/// Container over a FuzzySearchable that allows caching of metadata generated while
+/// fuzzying.
+///
+/// This allows for improved performance when fuzzy-searching multiple times 
+/// objects that don't change the contents of `fuzzyStringToMatch` too often.
 public struct CachedFuzzySearchable<T> : FuzzySearchable where T : FuzzySearchable {
     internal let searchable: T
-    internal let fuzzyCache = FuzzyCache()
+    internal let fuzzyCache: FuzzyCache
     
     public init(searchable: T) {
         self.searchable = searchable
+        self.fuzzyCache = FuzzyCache()
     }
     
     public var fuzzyStringToMatch: String {

--- a/Source/FuzzySearch.swift
+++ b/Source/FuzzySearch.swift
@@ -86,9 +86,7 @@ public struct CachedFuzzySearchable<T> : FuzzySearchable where T : FuzzySearchab
     public var fuzzyStringToMatch: String {
         return searchable.fuzzyStringToMatch
     }
-}
-
-extension CachedFuzzySearchable {
+    
     public func fuzzyTokenized() -> FuzzyTokens {
         // Re-create fuzzy cache, if stale
         if fuzzyCache.hash == nil || fuzzyCache.hash != fuzzyStringToMatch.hashValue {

--- a/Source/FuzzySearch.swift
+++ b/Source/FuzzySearch.swift
@@ -76,8 +76,8 @@ public extension FuzzySearchable {
     }
 }
 
-/// Container over a FuzzySearchable that allows caching of metadata generated while
-/// fuzzying.
+/// Container over a FuzzySearchable that allows caching of metadata generated
+/// while fuzzying.
 ///
 /// This allows for improved performance when fuzzy-searching multiple times 
 /// objects that don't change the contents of `fuzzyStringToMatch` too often.

--- a/Source/FuzzySearch.swift
+++ b/Source/FuzzySearch.swift
@@ -15,6 +15,7 @@ private struct CharOpts {
 
 /// A private cache containing pre-parsed metadata from a previous `.fuzzyMatch`
 /// call.
+/// Used by CachedFuzzySearchable<T> bellow.
 public class FuzzyCache {
     /// Hash of last fuzzed string
     fileprivate var hash: Int?
@@ -78,9 +79,18 @@ public extension FuzzySearchable {
     }
 }
 
-/// Variant of FuzzySearchable that allows for caching of the fuzzy strings
-public protocol CachedFuzzySearchable: FuzzySearchable {
-    var fuzzyCache: FuzzyCache { get }
+/// Container over a FuzzySearchable that allows caching of the fuzzy contents.
+public struct CachedFuzzySearchable<T> : FuzzySearchable where T : FuzzySearchable {
+    fileprivate let searchable: T
+    fileprivate var fuzzyCache = FuzzyCache()
+    
+    public init(searchable: T) {
+        self.searchable = searchable
+    }
+    
+    public var fuzzyStringToMatch: String {
+        return searchable.fuzzyStringToMatch
+    }
 }
 
 extension CachedFuzzySearchable {

--- a/Source/FuzzySearch.swift
+++ b/Source/FuzzySearch.swift
@@ -85,7 +85,7 @@ public struct CachedFuzzySearchable<T> : FuzzySearchable where T : FuzzySearchab
     internal let searchable: T
     internal let fuzzyCache: FuzzyCache
     
-    public init(searchable: T) {
+    public init(wrapping searchable: T) {
         self.searchable = searchable
         self.fuzzyCache = FuzzyCache()
     }

--- a/Tests/FuzzySearchTests.swift
+++ b/Tests/FuzzySearchTests.swift
@@ -15,9 +15,8 @@ extension String: FuzzySearchable {
     }
 }
 
-struct CachedString: CachedFuzzySearchable {
+class CacheableString: FuzzySearchable {
     var fuzzyStringToMatch: String
-    var fuzzyCache: FuzzyCache = FuzzyCache()
     
     init(_ value: String) {
         self.fuzzyStringToMatch = value
@@ -41,7 +40,7 @@ class FuzzySearchTests: XCTestCase {
     }
     
     func testThatConsecutiveMatchingGives2xForEachChar_Cached() {
-        let str = CachedString("Ladies Wash, Cut & Blow Dry")
+        let str = CachedFuzzySearchable(searchable: "Ladies Wash, Cut & Blow Dry")
         
         XCTAssertEqual(str.fuzzyMatch("l").weight, 1)
         XCTAssertEqual(str.fuzzyMatch("la").weight, 4)
@@ -51,7 +50,8 @@ class FuzzySearchTests: XCTestCase {
     }
     
     func testThatChangingFuzzyStringAffectsCache() {
-        var str = CachedString("Ladies Wash, Cut & Blow Dry")
+        let source = CacheableString("Ladies Wash, Cut & Blow Dry")
+        let str = CachedFuzzySearchable(searchable: source)
         
         XCTAssertEqual(str.fuzzyMatch("l").weight, 1)
         XCTAssertEqual(str.fuzzyMatch("la").weight, 4)
@@ -59,7 +59,7 @@ class FuzzySearchTests: XCTestCase {
         XCTAssertEqual(str.fuzzyMatch("ladi").weight, 26)
         XCTAssertEqual(str.fuzzyMatch("ladie").weight, 57)
         
-        str.fuzzyStringToMatch = "Weird Assassin"
+        source.fuzzyStringToMatch = "Weird Assassin"
         
         XCTAssertEqual(str.fuzzyMatch("w").weight, 1)
         XCTAssertEqual(str.fuzzyMatch("we").weight, 4)
@@ -129,7 +129,7 @@ class FuzzySearchTests: XCTestCase {
         let path = Bundle(for: type(of: self)).path(forResource: "spanish-words", ofType: "json")!
         let jsonData = try! Data(contentsOf: URL(fileURLWithPath: path), options: .mappedIfSafe)
         let spanishWords: Array<String> = try! JSONSerialization.jsonObject(with: jsonData as Data, options: JSONSerialization.ReadingOptions.mutableContainers) as! Array<String>
-        let spanishWordsCached = spanishWords.map(CachedString.init)
+        let spanishWordsCached = spanishWords.map(CachedFuzzySearchable.init)
         
         measure {
             _ = spanishWordsCached.fuzzyMatch("la sart")

--- a/Tests/FuzzySearchTests.swift
+++ b/Tests/FuzzySearchTests.swift
@@ -120,7 +120,14 @@ class FuzzySearchTests: XCTestCase {
         let path = Bundle(for: type(of: self)).path(forResource: "spanish-words", ofType: "json")!
         let jsonData = try! Data(contentsOf: URL(fileURLWithPath: path), options: .mappedIfSafe)
         let spanishWords: Array<String> = try! JSONSerialization.jsonObject(with: jsonData as Data, options: JSONSerialization.ReadingOptions.mutableContainers) as! Array<String>
+        
         measure{
+            _ = spanishWords.fuzzyMatch("l")
+            _ = spanishWords.fuzzyMatch("la")
+            _ = spanishWords.fuzzyMatch("la ")
+            _ = spanishWords.fuzzyMatch("la s")
+            _ = spanishWords.fuzzyMatch("la sa")
+            _ = spanishWords.fuzzyMatch("la sar")
             _ = spanishWords.fuzzyMatch("la sart")
         }
     }
@@ -132,6 +139,12 @@ class FuzzySearchTests: XCTestCase {
         let spanishWordsCached = spanishWords.map(CachedFuzzySearchable.init)
         
         measure {
+            _ = spanishWordsCached.fuzzyMatch("l")
+            _ = spanishWordsCached.fuzzyMatch("la")
+            _ = spanishWordsCached.fuzzyMatch("la ")
+            _ = spanishWordsCached.fuzzyMatch("la s")
+            _ = spanishWordsCached.fuzzyMatch("la sa")
+            _ = spanishWordsCached.fuzzyMatch("la sar")
             _ = spanishWordsCached.fuzzyMatch("la sart")
         }
     }

--- a/Tests/FuzzySearchTests.swift
+++ b/Tests/FuzzySearchTests.swift
@@ -40,7 +40,7 @@ class FuzzySearchTests: XCTestCase {
     }
     
     func testThatConsecutiveMatchingGives2xForEachChar_Cached() {
-        let str = CachedFuzzySearchable(searchable: "Ladies Wash, Cut & Blow Dry")
+        let str = CachedFuzzySearchable(wrapping: "Ladies Wash, Cut & Blow Dry")
         
         XCTAssertEqual(str.fuzzyMatch("l").weight, 1)
         XCTAssertEqual(str.fuzzyMatch("la").weight, 4)

--- a/Tests/FuzzySearchTests.swift
+++ b/Tests/FuzzySearchTests.swift
@@ -51,7 +51,7 @@ class FuzzySearchTests: XCTestCase {
     
     func testThatChangingFuzzyStringAffectsCache() {
         let source = CacheableString("Ladies Wash, Cut & Blow Dry")
-        let str = CachedFuzzySearchable(searchable: source)
+        let str = CachedFuzzySearchable(wrapping: source)
         
         XCTAssertEqual(str.fuzzyMatch("l").weight, 1)
         XCTAssertEqual(str.fuzzyMatch("la").weight, 4)

--- a/Tests/FuzzySearchTests.swift
+++ b/Tests/FuzzySearchTests.swift
@@ -15,6 +15,15 @@ extension String: FuzzySearchable {
     }
 }
 
+struct CachedString: CachedFuzzySearchable {
+    var fuzzyStringToMatch: String
+    var fuzzyCache: FuzzyCache = FuzzyCache()
+    
+    init(_ value: String) {
+        self.fuzzyStringToMatch = value
+    }
+}
+
 extension NSRange: Equatable {}
 public func ==(lhs: NSRange, rhs: NSRange) -> Bool {
     return lhs.length == rhs.length && lhs.location == rhs.location
@@ -29,6 +38,33 @@ class FuzzySearchTests: XCTestCase {
         XCTAssertEqual(str.fuzzyMatch("lad").weight, 11)
         XCTAssertEqual(str.fuzzyMatch("ladi").weight, 26)
         XCTAssertEqual(str.fuzzyMatch("ladie").weight, 57)
+    }
+    
+    func testThatConsecutiveMatchingGives2xForEachChar_Cached() {
+        let str = CachedString("Ladies Wash, Cut & Blow Dry")
+        
+        XCTAssertEqual(str.fuzzyMatch("l").weight, 1)
+        XCTAssertEqual(str.fuzzyMatch("la").weight, 4)
+        XCTAssertEqual(str.fuzzyMatch("lad").weight, 11)
+        XCTAssertEqual(str.fuzzyMatch("ladi").weight, 26)
+        XCTAssertEqual(str.fuzzyMatch("ladie").weight, 57)
+    }
+    
+    func testThatChangingFuzzyStringAffectsCache() {
+        var str = CachedString("Ladies Wash, Cut & Blow Dry")
+        
+        XCTAssertEqual(str.fuzzyMatch("l").weight, 1)
+        XCTAssertEqual(str.fuzzyMatch("la").weight, 4)
+        XCTAssertEqual(str.fuzzyMatch("lad").weight, 11)
+        XCTAssertEqual(str.fuzzyMatch("ladi").weight, 26)
+        XCTAssertEqual(str.fuzzyMatch("ladie").weight, 57)
+        
+        str.fuzzyStringToMatch = "Weird Assassin"
+        
+        XCTAssertEqual(str.fuzzyMatch("w").weight, 1)
+        XCTAssertEqual(str.fuzzyMatch("we").weight, 4)
+        XCTAssertEqual(str.fuzzyMatch("wei").weight, 11)
+        XCTAssertEqual(str.fuzzyMatch("weir").weight, 26)
     }
     
     func testThatCorrectMatchingPartsAreReturned() {
@@ -86,6 +122,17 @@ class FuzzySearchTests: XCTestCase {
         let spanishWords: Array<String> = try! JSONSerialization.jsonObject(with: jsonData as Data, options: JSONSerialization.ReadingOptions.mutableContainers) as! Array<String>
         measure{
             _ = spanishWords.fuzzyMatch("la sart")
+        }
+    }
+    
+    func testSpeedOfFuzzySearchFor1000SpanishWords_cached() {
+        let path = Bundle(for: type(of: self)).path(forResource: "spanish-words", ofType: "json")!
+        let jsonData = try! Data(contentsOf: URL(fileURLWithPath: path), options: .mappedIfSafe)
+        let spanishWords: Array<String> = try! JSONSerialization.jsonObject(with: jsonData as Data, options: JSONSerialization.ReadingOptions.mutableContainers) as! Array<String>
+        let spanishWordsCached = spanishWords.map(CachedString.init)
+        
+        measure {
+            _ = spanishWordsCached.fuzzyMatch("la sart")
         }
     }
 }


### PR DESCRIPTION
As discussed in #2, this is an explicit structure that wraps over an existing, non-cacheable `FuzzySearchable`, providing a thin layer that allows for caching of the tokenized searchable string.

This version has a few advantages that I'm planning on checking and proving related to resilience against sharing cache across multiple value-type `FuzzySearchable` implementers, since the implementer is copied into a private, constant field within the `CachedFuzzySearchable<T>` wrapper.